### PR TITLE
Bug fix when calling `dumpHands`

### DIFF
--- a/src/handy-work.js
+++ b/src/handy-work.js
@@ -125,7 +125,7 @@ export function generatePose(inputSources, referenceSpace, frame, float32Array) 
 			size +      // weighting for individual joints left hand
 			size        // weighting for individual joints right hand
 
-		if (float32Array.byteLength < bufferSize * 4) {
+		if (float32Array !== undefined && float32Array.byteLength < bufferSize * 4) {
 			throw Error(`Provided buffer too small it needs to be a float32 and the size needs to be ${bufferSize} (${bufferSize * 4} bytes)`)
 		}
 		const outData = float32Array || new Float32Array(bufferSize);


### PR DESCRIPTION
When calling `dumpHands`, `generatePose` is called without the `float32Array` parameter. This leads to a runtime exception on line 128 when `float32Array`, which is undefined, is dereferenced to access the `byteLength` field. This commit checks if `float32Array` is undefined before the expression above is run.

Tested and works when calling `dumpHands`.