### PR TITLE
Fix commands on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "docs1": "awk '\n BEGIN {p=1}\n /^<!--DOCS-->/ {print;system(\"npx jsdoc-to-markdown ./src/handy-work.js\");p=0}\n /^<!--DOCS_END-->/ {p=1}\n p' README.md > ~README.md && mv ~README.md README.md",
     "docs2": "awk '\n BEGIN {p=1}\n /^<!--SCHEMA-->/ {print;system(\"node ./aframe-to-md.mjs ./build/handy-controls.min.js\");p=0}\n /^<!--SCHEMA_END-->/ {p=1}\n p' README-AFRAME.md > ~README-AFRAME.md && mv ~README-AFRAME.md README-AFRAME.md",
     "docs3": "awk '\n BEGIN {p=1}\n /^<!--SCHEMA2-->/ {print;system(\"node ./aframe-to-md.mjs ./src/magnet-helpers.js\");p=0}\n /^<!--SCHEMA2_END-->/ {p=1}\n p' README-AFRAME.md > ~README-AFRAME.md && mv ~README-AFRAME.md README-AFRAME.md",
-    "docs": "npm run docs1 && npm run docs2 && npm run docs3;",
+    "docs": "npm run docs1 && npm run docs2 && npm run docs3",
     "build": "rollup -c && rollup -c ./rollup-aframe.config.js && rollup -c ./rollup-standalone.config.js && rollup -f cjs ./build/esm/handy-work.standalone.js -o ./build/cjs/handy-work.standalone.js && rollup -c -p rollup-plugin-terser && find build -maxdepth 2 -iname \"*.js\" -not -type d -exec du -h {} \\;;npm run docs",
     "develop": "rollup -w -c",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/rollup-standalone.config.js
+++ b/rollup-standalone.config.js
@@ -3,7 +3,9 @@ import { execSync } from 'child_process';
 import { terser } from "rollup-plugin-terser";
 import path from 'path';
 
-const handposeWorkerCompileCmd = path.resolve(`./node_modules/.bin/rollup -f esm -p "rollup-plugin-terser" ./build/esm/handpose.js`);
+const rollupPath = path.resolve('./node_modules/.bin/rollup');
+const handPoseEsmBuildPath = path.resolve('./build/esm/handpose.js');
+const handposeWorkerCompileCmd = `${rollupPath} -f esm -p "rollup-plugin-terser" ${handPoseEsmBuildPath}`;
 const handposeSrc = '`\n' + execSync(handposeWorkerCompileCmd) + '`';
 
 export default {

--- a/rollup-standalone.config.js
+++ b/rollup-standalone.config.js
@@ -1,8 +1,9 @@
 import replace from '@rollup/plugin-replace';
 import { execSync } from 'child_process';
 import { terser } from "rollup-plugin-terser";
+import path from 'path';
 
-const handposeWorkerCompileCmd = `./node_modules/.bin/rollup -f esm -p "rollup-plugin-terser" ./build/esm/handpose.js`;
+const handposeWorkerCompileCmd = path.resolve(`./node_modules/.bin/rollup -f esm -p "rollup-plugin-terser" ./build/esm/handpose.js`);
 const handposeSrc = '`\n' + execSync(handposeWorkerCompileCmd) + '`';
 
 export default {


### PR DESCRIPTION
While setting the repo up to work on again I noticed that some of the npm commands were failing, as they appear to assume a Unix-like environment. These small adjustments fix the docs command and allow the standalone bundle to build on Windows.