### PR TITLE
Sync with latest three XRControllerModelFactory

### DIFF
--- a/src/handy-controls.js
+++ b/src/handy-controls.js
@@ -1,7 +1,7 @@
 /* global AFRAME, THREE */
 import { XRControllerModelFactory } from './lib/XRControllerModelFactory.js';
 const __version__ = __version__;
-const DEFAULT_PROFILES_PATH = "https://cdn.jsdelivr.net/npm/@webxr-input-profiles/assets/dist/profiles";
+const DEFAULT_PROFILES_PATH = "https://cdn.jsdelivr.net/npm/@webxr-input-profiles/assets@1.0/dist/profiles";
 const DEFAULT_HAND_PROFILE_PATH = DEFAULT_PROFILES_PATH + "/generic-hand";
 const LIB_URL = "https://cdn.jsdelivr.net/npm/handy-work" + (__version__ ? '@' + __version__ : '');
 const LIB = LIB_URL + "/build/esm/handy-work.standalone.js";
@@ -94,7 +94,8 @@ AFRAME.registerComponent("handy-controls", {
     const self = this;
     const dracoLoader = this.el.sceneEl.systems['gltf-model'].getDRACOLoader();
     const meshoptDecoder = this.el.sceneEl.systems['gltf-model'].getMeshoptDecoder();
-    this.controllerModelFactory = new XRControllerModelFactory(this.loader, DEFAULT_PROFILES_PATH);
+    this.controllerModelFactory = new XRControllerModelFactory(this.loader);
+    this.controllerModelFactory.setPath(DEFAULT_PROFILES_PATH);
     this.model = null;
     if (dracoLoader) {
       this.loader.setDRACOLoader(dracoLoader);

--- a/src/lib/XRControllerModelFactory.js
+++ b/src/lib/XRControllerModelFactory.js
@@ -12,7 +12,7 @@ import {
 	MotionController
 } from 'three/examples/jsm/libs/motion-controllers.module.js';
 
-const DEFAULT_PROFILES_PATH = 'https://cdn.jsdelivr.net/npm/@webxr-input-profiles/assets/dist/profiles';
+const DEFAULT_PROFILES_PATH = 'https://cdn.jsdelivr.net/npm/@webxr-input-profiles/assets@1.0/dist/profiles';
 const DEFAULT_PROFILE = 'generic-trigger';
 
 class XRControllerModel extends Object3D {
@@ -205,11 +205,20 @@ function addAssetSceneToControllerModel( controllerModel, scene ) {
 
 class XRControllerModelFactory {
 
-	constructor( gltfLoader, path ) {
+	constructor( gltfLoader, onLoad = null ) {
 
 		this.gltfLoader = gltfLoader;
-		this.path = path || DEFAULT_PROFILES_PATH;
+		this.path = DEFAULT_PROFILES_PATH;
 		this._assetCache = {};
+		this.onLoad = onLoad;
+
+	}
+
+	setPath( path ) {
+
+		this.path = path;
+
+		return this;
 
 	}
 
@@ -222,7 +231,7 @@ class XRControllerModelFactory {
 
 			const xrInputSource = event.data;
 
-			if ( xrInputSource.targetRayMode !== 'tracked-pointer' || ! xrInputSource.gamepad ) return;
+			if ( xrInputSource.targetRayMode !== 'tracked-pointer' || ! xrInputSource.gamepad || xrInputSource.hand ) return;
 
 			fetchProfile( xrInputSource, this.path, DEFAULT_PROFILE ).then( ( { profile, assetPath } ) => {
 
@@ -257,6 +266,8 @@ class XRControllerModelFactory {
 
 					addAssetSceneToControllerModel( controllerModel, scene );
 
+					if ( this.onLoad ) this.onLoad( scene );
+
 				} else {
 
 					if ( ! this.gltfLoader ) {
@@ -273,6 +284,8 @@ class XRControllerModelFactory {
 						scene = asset.scene.clone();
 
 						addAssetSceneToControllerModel( controllerModel, scene );
+
+						if ( this.onLoad ) this.onLoad( scene );
 
 					},
 					null,


### PR DESCRIPTION
Sync with latest https://github.com/mrdoob/three.js/commits/dev/examples/jsm/webxr/XRControllerModelFactory.js that contains https://github.com/mrdoob/three.js/pull/29179/commits/2db27dffb65909a3c0f2aa2712a9c40ac960b306
that seems to fix the issue showing several times the controller model (you don't see the button being pressed) on Quest 3 v69 (not an issue on Quest 2).
Also put back `@1.0` in the jsdelivr url to get the profiles, here `@1.0` actually means get the latest version 1.0.x. 